### PR TITLE
Initial Unit test implementation using unittest

### DIFF
--- a/parsing/tokenize.py
+++ b/parsing/tokenize.py
@@ -340,8 +340,11 @@ class CommandTokenizer:
             >>> tokenizer.location  # 'EVENT'
             >>> tokenizer.verb      # 'ADD'
         """
-        self.tokens = self._parseCommand(command)
-        self.location = self.tokens[0]
-        self.verb = self.tokens[1]
-        self.context = self._getContext(self.tokens)
-        self.tokenObject = self._createTokenObject()
+        try:
+            self.tokens = self._parseCommand(command)
+            self.location = self.tokens[0]
+            self.verb = self.tokens[1]
+            self.context = self._getContext(self.tokens)
+            self.tokenObject = self._createTokenObject()
+        except:
+            self.tokenObject = None

--- a/tests/ParsingTests.py
+++ b/tests/ParsingTests.py
@@ -1,0 +1,24 @@
+import unittest
+from parsing.tokenize import CommandTokenizer
+
+class tokenizeTests(unittest.TestCase):
+
+    def test_commandTokenizerEventAdd(self):
+        print("For \'EVENT ADD meeting 25/12/2023 14:00 25/12/2023 15:00 \"Team meeting\"\' Expected value for location is EVENT and verb is ADD")
+        tokenizer = CommandTokenizer('EVENT ADD meeting 25/12/2023 14:00 25/12/2023 15:00 "Team meeting"')
+        self.assertEqual(tokenizer.location,"EVENT")
+        self.assertEqual(tokenizer.verb,"ADD")
+
+    def test_commandTokenizerEventAddFail(self):
+        print("Fail Invalid Command Expected Non Token Object")
+        tokenizer = CommandTokenizer('EVENT AD meeting 25/12/2023 14:00 25/12/2023 15:00 "Team meeting"')
+        self.assertEqual(tokenizer.tokenObject, None)
+
+    def test_commandTokenizerEventAddEmptyString(self):
+        print("Fail Empty String Expected None Token Object")
+        tokenizer = CommandTokenizer('')
+        self.assertEqual(tokenizer.tokenObject, None)
+  
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added ParsingTests.py and the tests directory
ammended tokenize.py to return None in situations where the users entry is incorrect may cause downstream exceptions and is an excise left to the user to resolve.